### PR TITLE
Update Eureka client service URL to use discovery server

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,7 +2,7 @@ spring.application.name=gtu-driver-tracker
 server.port=${SERVER_PORT:8082}
 
 eureka.instance.instance-id=${spring.application.name}:${spring.application.instance_id:${random.value}}
-eureka.client.service-url.defaultZone=http://${EUREKA_SERVER_HOST:localhost}:${EUREKA_SERVER_PORT:8761}/eureka/
+eureka.client.service-url.defaultZone=http://${EUREKA_SERVER_HOST:discovery-server}:${EUREKA_SERVER_PORT:8761}/eureka/
 eureka.client.register-with-eureka=true
 eureka.client.fetch-registry=true
 


### PR DESCRIPTION
This pull request updates the `application.properties` file to modify the Eureka server configuration, ensuring the application connects to the correct service discovery host.

Configuration update:

* [`src/main/resources/application.properties`](diffhunk://#diff-54eeffbae371fcd1398d4ca5e89a1b8118208b7bb2f8ddf55c1aa2f7d98ab136L5-R5): Changed the `defaultZone` in `eureka.client.service-url` from `localhost` to `discovery-server` to align with the updated service discovery setup.